### PR TITLE
fixed runtime light clamp for realtime lights and fxc miscompilation

### DIFF
--- a/Runtime/Shaders/SCSS_Core.cginc
+++ b/Runtime/Shaders/SCSS_Core.cginc
@@ -501,6 +501,8 @@ half3 SCSS_ApplyLighting(SCSS_Input c, SCSS_ShadingParam p)
 	effectLightShadow += d.sh.L0;
 	#endif
 
+    half effectLightingClampScale = 1;
+
     // Workaround for scenes with HDR off blowing out in VRchat.
     if (getLightClampActive())
     {
@@ -510,6 +512,8 @@ half3 SCSS_ApplyLighting(SCSS_Input c, SCSS_ShadingParam p)
 	    // Note: Not luminance, because the final output is still tinted by the output colour.
 	    // So bright blue light is OK because blue is still dark.
 	    half maxEffectLight = max3(effectLighting);
+        // Store original light intensity before remapping, scale output by this instead of clamped values
+        effectLightingClampScale = max(maxEffectLight, 1);
 	    // The effect lighting is remapped to be within the 0-1.25 range when clamped.
 	    half modLight = min(maxEffectLight, 1.25);
 	    // Scale the values by the highest value.
@@ -551,7 +555,7 @@ half3 SCSS_ApplyLighting(SCSS_Input c, SCSS_ShadingParam p)
 	// Apply the light scaling if the light clamp is active. When the light clamp is active,
 	// the final colour is divided by the main light intensity.
 	// Todo: Test in URP and see if it still makes sense.
-   	if (getLightClampActive()) finalColor = finalColor / max(max3(effectLighting), 1);
+   	if (getLightClampActive()) finalColor = finalColor / effectLightingClampScale;
 
 	finalColor *= _LightMultiplyAnimated;
 

--- a/Runtime/Shaders/SCSS_Core.cginc
+++ b/Runtime/Shaders/SCSS_Core.cginc
@@ -234,6 +234,9 @@ half3 getDirectSpecular(SCSS_Input c, SCSS_ShadingParam p, SCSS_LightParam d, Co
         }
 
         specularTerm = V * D * UNITY_PI; // Torrance-Sparrow
+        if (getLightClampActive()) {
+            specularTerm = specularTerm / max(max3(FLT_EPS + l.color), 1);
+        } 
         specularTerm = max(0, specularTerm * d.NdotL);
 
         return specularTerm * l.color * attenuation * FresnelTerm(c.specColor, d.LdotH) * _SpecularHighlights;

--- a/Runtime/Shaders/SCSS_Utils.cginc
+++ b/Runtime/Shaders/SCSS_Utils.cginc
@@ -831,8 +831,8 @@ half V_SmithGGXCorrelated(half roughness, half NoV, half NoL) {
     // Heitz 2014, "Understanding the Masking-Shadowing Function in Microfacet-Based BRDFs"
     half a2 = roughness * roughness;
     // TODO: lambdaV can be pre-computed for all the lights, it should be moved out of this function
-    half lambdaV = NoL * sqrt((NoV - a2 * NoV) * NoV + a2);
-    half lambdaL = NoV * sqrt((NoL - a2 * NoL) * NoL + a2);
+    half lambdaV = NoL * sqrt(max((NoV - a2 * NoV) * NoV + a2, 0.0));
+    half lambdaL = NoV * sqrt(max((NoL - a2 * NoL) * NoL + a2, 0.0));
     // 0.0000077 = nextafter(0.5 / MEDIUMP_FLT_MAX, 1.0) in fp16, so we don't overflow
     half v = PREVENT_DIV0(0.5, lambdaV + lambdaL, 0.0000077);
     // a2=0 => v = 1 / 4*NoL*NoV   => min=1/4, max=+inf


### PR DESCRIPTION
This fixes the issue with Runtime Light Clamp, allowing it to work again for realtime lights.

Also, the miscompilation issue with D4rk's optimizer is resolved here by setting a lower limit in the specular GGX calculation.